### PR TITLE
fixed findFieldByAttribute to look inside tabs fields

### DIFF
--- a/src/FieldCollection.php
+++ b/src/FieldCollection.php
@@ -19,4 +19,20 @@ class FieldCollection extends NovaFieldCollection
             return collect(Arr::get($tab, 'fields'))->whereInstanceOf($type);
         });
     }
+
+    public function findFieldByAttribute($attribute, $default = null)
+    {
+        foreach ($this->items as $field) {
+            if (isset($field->attribute) && $field->attribute === $attribute) {
+                return $field;
+            }
+
+            // Search the fields inside tabs.
+            if (is_array($field) && isset($field['component']) && $field['component'] === 'tabs') {
+                return static::make($field['fields'])->findFieldByAttribute($attribute, $default);
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
This fixes some nova packages which use `findFieldByAttribute`. Before this change, they never found the field they looked for if it was inside a tab. Now, `findFieldByAttribute` looks inside the tabs as well.

I hope you can include this change in your PR in the main repository!

Thanks